### PR TITLE
Exposed useful methods to make working with cubestate easier to derive colour information from it + some typescript tidy up

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This TypeScript library provides a representation of a Rubik's Cube and a set of
   - [Initializing a Rubik's Cube](#initializing-a-rubiks-cube)
   - [Checking the Cube's State](#checking-the-cubes-state)
   - [Rotating a Cube Layer](#rotating-a-cube-layer)
+  - [Rotating the Cube](#rotating-the-cube)
+  - [Deriving colour information from the cubestate](#deriving-colour-information-from-the-cubestate)
 - [Examples](#examples)
 - [Contributing](#contributing)
 - [License](#license)
@@ -95,6 +97,99 @@ cube.rotate(AxisVertex.PITCH, CubeRotationDirection.ClockWise);
 console.log(cubeState);
 ```
 
+### Deriving colour information from the cubestate
+
+Starting with a new CubeState instance and Cube Instance we can get the colour of all of the cubits of a given face colour using a combination of a few methods available via the module.
+```typescript
+const cubeState: CubeState = newCubeState();
+const cube: ICube = new Cube(cubeState);
+```
+
+We'd start by getting the layer normal for a colour. The layer normal is the Vertex that specifies the direction of a cubit and is the second part of a cubits complimentary pair.
+
+```typescript
+const colour: COLOURS = COLOURS.BLUE;
+const lnfc: Vertex = layerNormalForColour(cubeState, colour);
+```
+
+For a default cubestate, calling `layerNormalForColour` passing the colour `COLOURS.BLUE` will return a `Vertex` `[0, 0, 2]`. This is because by default the BLUE face of a new cube is at the back of the cube model.
+
+Now that we have the normal for the Blue face of the cube we can query `indecesForNormal` passing the normal Vertex to get a list of indices of all cubits that match this normal.
+```typescript
+const ifn: number[] = indecesForNormal(cubeState, lnfc);
+```
+
+`indecesForNormal` will return an array of indices that match the normal we passed to it. With the indices we can make a call to `colourForIndex` for each and get the corresponding `COLOURS` enum.
+
+```typescript
+const cfi: COLOURS[] = ifn.map((i: number) => {
+  return colourForIndex(i);
+});
+```
+
+We should now have an array of 9 `COLOURS` outputting the console like so:
+```typescript
+console.log(
+  `Colours for ${COLOURS[colour]}`,
+  cfi.map((c: COLOURS) => COLOURS[c]),
+);
+```
+
+A complete sample could look like this
+```typescript
+import {
+  Cube,
+  ICube,
+  CubeRotationDirection,
+  CubeState,
+  newCubeState,
+  COLOURS,
+  layerNormalForColour,
+  indecesForNormal,
+  Vertex,
+  colourForIndex
+} from '@markforster/cubits';
+
+const logColoursForColourToConsole = (
+  cubeState: CubeState,
+  colour: COLOURS,
+) => {
+  const lnfc: Vertex = layerNormalForColour(cubeState, colour);
+  const ifn: number[] = indecesForNormal(cubeState, lnfc);
+  const cfi: COLOURS[] = ifn.map((i: number) => colourForIndex(i));
+
+  console.log(
+    `Colours for ${COLOURS[colour]}`,
+    cfi.map((c: COLOURS) => COLOURS[c]),
+  );
+};
+
+const cubeState: CubeState = newCubeState();
+const cube: ICube = new Cube(cubeState);
+
+logColoursForColourToConsole(cubeState, COLOURS.BLUE);
+
+cube.rotateLayerForColour(COLOURS.WHITE, CubeRotationDirection.ClockWise);
+
+logColoursForColourToConsole(cubeState, COLOURS.BLUE);
+```
+and our console output would look like this
+```console
+Colours for BLUE [
+  'BLUE', 'BLUE',
+  'BLUE', 'BLUE',
+  'BLUE', 'BLUE',
+  'BLUE', 'BLUE',
+  'BLUE'
+]
+Colours for BLUE [
+  'BLUE',   'BLUE',
+  'BLUE',   'BLUE',
+  'BLUE',   'BLUE',
+  'ORANGE', 'ORANGE',
+  'ORANGE'
+]
+```
 ## Examples
 
 Check the [examples](./examples) directory for additional usage scenarios and demonstrations.

--- a/examples/example10.ts
+++ b/examples/example10.ts
@@ -1,0 +1,32 @@
+import { CubeState } from '../src/cube';
+import { Cube } from '../src/cube/Cube';
+import { ICube } from '../src/cube/ICube';
+import { CubeRotationDirection, Vertex } from '../src/cube/lib';
+import { colourForIndex } from '../src/lib/colourForIndex';
+import { COLOURS } from '../src/lib/colours';
+import { newCubeState } from '../src/lib/factory';
+import { indecesForNormal } from '../src/lib/indecesForNormal';
+import { layerNormalForColour } from '../src/lib/layerVertexForColour';
+
+const logColoursForColourToConsole = (
+  cubeState: CubeState,
+  colour: COLOURS,
+) => {
+  const lnfc: Vertex = layerNormalForColour(cubeState, colour);
+  const indices: any[] = indecesForNormal(cubeState, lnfc);
+  const colours: any[] = indices.map((i: number) => colourForIndex(i));
+
+  console.log(
+    `Colours for ${COLOURS[colour]}`,
+    colours.map((c: COLOURS) => COLOURS[c]),
+  );
+};
+
+const cubeState: CubeState = newCubeState();
+const cube: ICube = new Cube(cubeState);
+
+logColoursForColourToConsole(cubeState, COLOURS.BLUE);
+
+cube.rotateLayerForColour(COLOURS.WHITE, CubeRotationDirection.ClockWise);
+
+logColoursForColourToConsole(cubeState, COLOURS.BLUE);

--- a/examples/lib/index.ts
+++ b/examples/lib/index.ts
@@ -16,20 +16,20 @@ export const consoleColors: any = {
   [COLOURS.RED]: 160,
 };
 
-export const StringIsNumber = (value) => isNaN(Number(value)) === false;
-export const NotStringIsNumber = (value) => isNaN(Number(value)) === true;
+export const StringIsNumber = (value: any) => isNaN(Number(value)) === false;
+export const NotStringIsNumber = (value: any) => isNaN(Number(value)) === true;
 
 // Turn enum into array
-export function KeysForEnum(enumme): any[] {
-  return Object.keys(enumme)
+export function KeysForEnum(_enum: any): any[] {
+  return Object.keys(_enum)
     .filter(StringIsNumber)
-    .map((key) => enumme[key]);
+    .map((key) => _enum[key]);
 }
 
-export function ValuesForEnum(enumme): any[] {
-  return Object.keys(enumme)
+export function ValuesForEnum(_enum: any): any[] {
+  return Object.keys(_enum)
     .filter(NotStringIsNumber)
-    .map((key) => enumme[key]);
+    .map((key) => _enum[key]);
 }
 
 export const showCubeDetails = (cube: ICube, title?: string) => {

--- a/examples/package.json
+++ b/examples/package.json
@@ -10,11 +10,14 @@
   "author": "markforster",
   "license": "MIT",
   "dependencies": {
-    "@types/node": "^20.4.5",
     "cli-color": "^2.0.3",
     "cli-table3": "^0.6.3",
     "i": "^0.3.7",
     "npm": "^10.2.3",
     "ts-node": "^10.9.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.4.5",
+    "@types/cli-color": "^2.0.5"
   }
 }

--- a/examples/render.ts
+++ b/examples/render.ts
@@ -6,7 +6,7 @@ import { COLOURS } from '../src/lib/colours';
 import { colourForIndex } from '../src/lib/colourForIndex';
 import { Vector } from '../src/cube/lib';
 
-const n = null;
+const n: any = null;
 
 const consoleColors: any = {
   [n]: 0,
@@ -29,7 +29,7 @@ enum FACE {
 
 const FL = ['U', 'F', 'D', 'B', 'L', 'R'];
 
-const map: number[][] = [
+const map: (number | null)[][] = [
   [n, n, n, n, n, n, n, n, n],
   [n, n, n, n, n, n, n, n, n],
   [n, n, n, n, n, n, n, n, n],
@@ -59,9 +59,7 @@ const map2: number[][] = [
   [n, n, n, n, n, n, n, n, n],
 ];
 
-const MSYM = {};
-
-const lookup = {
+const lookup: Record<string, [number, number]> = {
   // Top Face
   '-11-1-12-1': [3, 5],
   '01-102-1': [4, 5],
@@ -132,23 +130,22 @@ const lookup = {
 export const render = (cubeState: CubeState, padding?: number): string => {
   cubeState.forEach((v: Vector, index: number) => {
     const key = `${v[0][0]}${v[0][1]}${v[0][2]}${v[1][0]}${v[1][1]}${v[1][2]}`;
+
     if (lookup[key]) {
-      map[lookup[key][1]][lookup[key][0]] = lookup[key]
-        ? colourForIndex(index)
-        : null;
+      const coords: [number, number] = lookup[key];
+      // map[coords[1]][coords[0]] = null;
+      map[coords[1]][coords[0]] = lookup[key] ? colourForIndex(index) : null;
     }
   });
 
   const s: any = map
-    .map((c: number[], ci: number) => {
+    .map((c: (number | null)[], ci: number) => {
       return `${' '.repeat(padding || 0)}${c
-        .map((d: number, di) => {
+        .map((d: number | null, di) => {
           const ltr = map2[ci][di] !== null ? `${FL[map2[ci][di]]} ` : '█ ';
           const bgc = map2[ci][di] !== null ? 0 : 0;
-          const fgc =
-            map2[ci][di] !== null ? consoleColors[d] : consoleColors[d];
+          const fgc = map2[ci][di] !== null && d ? consoleColors[d] : consoleColors[d];
 
-          // return clc.xterm(consoleColors[d])('█ ');
           return clc.xterm(fgc).bgXterm(bgc)(ltr);
         })
         .reduce((v, s) => `${v}${s}`)}${ci !== map.length - 1 ? '\n' : ''}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,13 @@
+export { colourForIndex } from './lib/colourForIndex';
+export { indecesForNormal } from './lib/indecesForNormal';
+export { layerNormalForColour } from './lib/layerVertexForColour';
+export { newCubeState } from './lib/factory';
+
+export { COLOURS } from './lib/colours';
+export { CubeState } from './cube/';
+
 export { Cube } from './cube/Cube';
 export { ICube } from './cube/ICube';
 export { Vector, Vertex, CubeRotationDirection } from './cube/lib';
-export { COLOURS } from './lib/colours';
-export { CubeState } from './cube/';
+
 export { AxisVertex } from './lib/';
-export { newCubeState } from './lib/factory';

--- a/src/lib/colourForIndex.ts
+++ b/src/lib/colourForIndex.ts
@@ -13,7 +13,9 @@
  * console.log(color2); // Output: 1
  */
 
-export function colourForIndex(index: number): number {
+import { COLOURS } from './colours';
+
+export function colourForIndex(index: number): COLOURS {
   // Improving the code: Add input validation to handle non-numeric and negative index values.
   if (typeof index !== 'number' || isNaN(index) || index < 0) {
     throw new Error(
@@ -22,5 +24,5 @@ export function colourForIndex(index: number): number {
   }
 
   // Calculate the color value by dividing the index by 9 and rounding down.
-  return Math.floor(index / 9.0);
+  return Math.floor(index / 9.0) as COLOURS;
 }


### PR DESCRIPTION
Exposed the methods layerNormalForColour, indecesForNormal and colourForIndex. Updated the README file with examples on how to use these methods. Added a new example (1) showing this also. Fixed typescript errors in examples lib (index.ts) file and the render.ts file used to render the cube map in the sandbox sample. Also correct some typescript issues in other files.