### PR TITLE
Fix typo in cube normals constant

### DIFF
--- a/src/cube/Face.ts
+++ b/src/cube/Face.ts
@@ -1,5 +1,5 @@
 import { CubeState } from '.';
-import { NormlasVertex, indicesForNormal } from '../lib';
+import { NormalsVertex, indicesForNormal } from '../lib';
 import { colourForIndex } from '../lib/colourForIndex';
 import { COLOURS } from '../lib/colours';
 import { FaceOption, faceOrientationKeys, faceColourKeys } from '../lib/face';
@@ -31,7 +31,7 @@ export class Face implements IFace {
     if (faceOrientationKeys.includes(this._option)) {
       const ifn: number[] = indicesForNormal(
         this._cubeState,
-        Object.values(NormlasVertex)[orientationForFaceOption(this._option)],
+        Object.values(NormalsVertex)[orientationForFaceOption(this._option)],
       );
       const cfi: COLOURS[] = ifn.map((i: number) => colourForIndex(i));
       return cfi;
@@ -51,7 +51,7 @@ export class Face implements IFace {
     if (faceOrientationKeys.includes(this._option)) {
       const ifn: number[] = indicesForNormal(
         this._cubeState,
-        Object.values(NormlasVertex)[orientationForFaceOption(this._option)],
+        Object.values(NormalsVertex)[orientationForFaceOption(this._option)],
       );
 
       return ifn.map((i: number) => i);
@@ -73,7 +73,7 @@ export class Face implements IFace {
     if (faceOrientationKeys.includes(this._option)) {
       const ifn: number[] = indicesForNormal(
         this._cubeState,
-        Object.values(NormlasVertex)[orientationForFaceOption(this._option)],
+        Object.values(NormalsVertex)[orientationForFaceOption(this._option)],
       );
       return ifn.map((i: number) => {
         return this._cubeState[i][1].map((ii: number) => ii) as Vertex;
@@ -96,7 +96,7 @@ export class Face implements IFace {
     if (faceOrientationKeys.includes(this._option)) {
       const ifn: number[] = indicesForNormal(
         this._cubeState,
-        Object.values(NormlasVertex)[orientationForFaceOption(this._option)],
+        Object.values(NormalsVertex)[orientationForFaceOption(this._option)],
       );
       return ifn.map((i: number) => {
         return this._cubeState[i][0].map((ii: number) => ii) as Vertex;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -27,7 +27,7 @@ export const LayersVertex: Record<string, Vertex> = Object.freeze({
   // Add more matrices as needed
 } as const);
 
-export const NormlasVertex: Record<string, Vertex> = Object.freeze({
+export const NormalsVertex: Record<string, Vertex> = Object.freeze({
   TOP: [0, 2, 0] as Vertex,
   BOTTOM: [0, -2, 0] as Vertex,
   FRONT: [0, 0, -2] as Vertex,


### PR DESCRIPTION
## Summary
- rename `NormlasVertex` to `NormalsVertex`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e1f3ca64833284f6996ca4f86389