### PR TITLE
Fix back layer rotation direction

### DIFF
--- a/src/lib/rotateLayer.ts
+++ b/src/lib/rotateLayer.ts
@@ -22,7 +22,7 @@ export function rotateLayer(
     if (layer === LAYERS.MIDDLE) return [AxisVertex.PITCH, angle];
 
     if (layer === LAYERS.FRONT) return [AxisVertex.ROLL, angle];
-    if (layer === LAYERS.BACK) return [AxisVertex.ROLL, angle];
+    if (layer === LAYERS.BACK) return [AxisVertex.ROLL, -angle];
     if (layer === LAYERS.STANDING) return [AxisVertex.ROLL, angle];
   })();
 

--- a/src/lib/tests/rotateLayer.test.ts
+++ b/src/lib/tests/rotateLayer.test.ts
@@ -430,8 +430,10 @@ describe(`Rotating layers`, () => {
       rotateLayer(Layer.BACK, CubeRotationDirection.ClockWise, cubeState);
 
       expect(coloursForVertices(bI, cubeState)).toEqual(ALL_BLUE_COLOURS);
-      expect(coloursForVertices(ubI, cubeState)).toEqual([cO, cO, cO]);
-      expect(coloursForVertices(lbI, cubeState)).toEqual([cY, cY, cY]);
+      expect(coloursForVertices(ubI, cubeState)).toEqual([cR, cR, cR]);
+      // The left back column should now contain what was previously the
+      // upper back row.
+      expect(coloursForVertices(lbI, cubeState)).toEqual([cW, cW, cW]);
     });
   });
 
@@ -464,8 +466,8 @@ describe(`Rotating layers`, () => {
       rotateLayer(Layer.BACK, CubeRotationDirection.AntiClockWise, cubeState);
 
       expect(coloursForVertices(bI, cubeState)).toEqual(ALL_BLUE_COLOURS);
-      expect(coloursForVertices(ubI, cubeState)).toEqual([cR, cR, cR]);
-      // expect(coloursForVertices(lbI, cubeState)).toEqual([cY, cY, cY]);
+      expect(coloursForVertices(ubI, cubeState)).toEqual([cO, cO, cO]);
+      expect(coloursForVertices(lbI, cubeState)).toEqual([cY, cY, cY]);
     });
   });
 


### PR DESCRIPTION
## Summary
- fix Back layer rotation axis sign in `rotateLayer`
- update tests for new back layer behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea969e10083328959ceb8eeef427a