### PR TITLE
Refactor rotate layer vertex helper

### DIFF
--- a/src/lib/rotateLayerForVertex.ts
+++ b/src/lib/rotateLayerForVertex.ts
@@ -1,8 +1,7 @@
-import { CubeState } from '../cube';
-import { Vertex, RotationAngle } from '../cube/lib';
-import { rotateVectorsAtindices } from '.';
-import { indicesForverticesInLayer } from './indicesForVerticesInLayer';
-// import { indicesForvertices } from './indicesForvertices';
+import { CubeState } from "../cube";
+import { Vertex, RotationAngle } from "../cube/lib";
+import { rotateVectorsAtindices } from ".";
+import { indicesForvertices } from "./indicesForvertices";
 
 export const rotateLayerForVertex = (
   cubeState: CubeState,
@@ -10,8 +9,7 @@ export const rotateLayerForVertex = (
   rotationAxis: Vertex,
   angle: RotationAngle,
 ) => {
-  // TODO: Should use indicesForvertices!!! indicesForverticesInLayer is deprecated
-  const indices: number[] = indicesForverticesInLayer(cubeState, vertex);
-  // const indices: number[] = indicesForvertices(cubeState, vertex);
+  const layerVertex = vertex.map((v) => (v === 0 ? undefined : v)) as Vertex;
+  const indices: number[] = indicesForvertices(cubeState, layerVertex);
   rotateVectorsAtindices(cubeState, indices, angle, rotationAxis);
 };

--- a/src/lib/tests/rotateLayerForVertex.test.ts
+++ b/src/lib/tests/rotateLayerForVertex.test.ts
@@ -1,0 +1,26 @@
+import { compareArray } from "..";
+import { CubeState } from "../../cube";
+import { RotationAngle, Vertex } from "../../cube/lib";
+import { AxisVertex } from "..";
+import { rotateLayerForVertex } from "../rotateLayerForVertex";
+import { newCubeState } from "../factory";
+import { expectDefaultCubeState } from "./lib";
+
+describe("rotateLayerForVertex", () => {
+  it("rotates the top layer when given [0,1,0]", () => {
+    const cubeState: CubeState = newCubeState();
+
+    expectDefaultCubeState(cubeState);
+
+    rotateLayerForVertex(
+      cubeState,
+      [0, 1, 0] as Vertex,
+      AxisVertex.YAW,
+      RotationAngle.ClockWise,
+    );
+
+    expect(compareArray(cubeState[0][0], [-1, 1, 1])).toBe(true);
+    expect(compareArray(cubeState[1][0], [-1, 1, 0])).toBe(true);
+    expect(compareArray(cubeState[2][0], [-1, 1, -1])).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- use `indicesForvertices` in `rotateLayerForVertex`
- normalise given vertex before computing indices
- add coverage for `rotateLayerForVertex`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686eb239b39c83329ed2f4118a9a8ba5