### PR TITLE
Make cube state read-only via getter

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -95,7 +95,7 @@ The Cube uses an internal property called state to manage the information about 
 An instance of a cube can be created passing a CubeState to its constructor allowing you to see changes made to the state directly from manipulate through a cubes ICube interface.
 
 > [!CAUTION]
-> Cubestate is intentionally hidden within a Cube instance. Work is ongoing to expose cubestate via its private property as readonly but this feature is yet to be added. Caution should be taken directly accessing the cube state as changes to the inner Vertices could cause features to break. See details here [src/cube/index.ts](../blob/master/src/cube/index.ts).
+> From v0.2.2 `cube.state` returns a snapshot of the cubes internal state. The returned value is a deep clone and mutating it will **not** alter the cube. Directly referencing the internal state is still possible by storing the `CubeState` passed to the constructor.
 
 ```typescript
 import {

--- a/src/cube/Cube.ts
+++ b/src/cube/Cube.ts
@@ -17,14 +17,21 @@ import { IFace } from './IFace';
 import { CubeRotationDirection, Orientation } from './lib';
 
 export class Cube implements ICube {
-  readonly state: CubeState;
+  private readonly _state: CubeState;
 
   constructor(cubeState?: CubeState) {
-    this.state = cubeState || newCubeState();
+    this._state = cubeState || newCubeState();
+  }
+
+  get state(): CubeState {
+    return this._state.map(([p, o]) => [
+      [...p] as typeof p,
+      [...o] as typeof o,
+    ]) as CubeState;
   }
 
   solved(colour?: COLOURS): boolean {
-    return solved(this.state, colour);
+    return solved(this._state, colour);
   }
 
   orientate(
@@ -33,7 +40,7 @@ export class Cube implements ICube {
     lockedOrientation?: Orientation,
   ): void {
     rotateCubeState(
-      this.state,
+      this._state,
       LayersVertex[sourceOrientation],
       LayersVertex[targetOrientation],
       (lockedOrientation && LayersVertex[lockedOrientation]) || undefined,
@@ -43,8 +50,8 @@ export class Cube implements ICube {
   rotate(axis: Axis, direction: CubeRotationDirection, times?: number) {
     const angle = direction * FULL_ROTATION * (times ? times : 1);
     rotateVectorsAtindices(
-      this.state,
-      this.state.map((_v: any, i: number) => i),
+      this._state,
+      this._state.map((_v: any, i: number) => i),
       angle,
       AxisToVertex[KeysForEnum(Axis)[axis]],
     );
@@ -52,7 +59,7 @@ export class Cube implements ICube {
 
   rotateLayerForColour(colour: COLOURS, direction: CubeRotationDirection) {
     const angle = direction * FULL_ROTATION;
-    rotateLayerForColour(this.state, colour, angle);
+    rotateLayerForColour(this._state, colour, angle);
   }
 
   rotateLayer(
@@ -62,14 +69,14 @@ export class Cube implements ICube {
   ): void {
     if (times && times > 0 && times < 4) {
       for (let i = 0; i < times; i++) {
-        rotateLayer(layer, direction, this.state);
+        rotateLayer(layer, direction, this._state);
       }
     } else {
-      rotateLayer(layer, direction, this.state);
+      rotateLayer(layer, direction, this._state);
     }
   }
 
   face(option: FaceOption): IFace {
-    return faceForFaceOption(this.state, option);
+    return faceForFaceOption(this._state, option);
   }
 }

--- a/src/cube/ICube.ts
+++ b/src/cube/ICube.ts
@@ -13,9 +13,10 @@ import { CubeRotationDirection, Orientation } from './lib';
  */
 export interface ICubePuzzle {
   /**
-   * The current state of the Rubiks Cube.
+   * Snapshot of the cube's current state.
+   * Modifying this value will not affect the cube.
    */
-  state: CubeState;
+  readonly state: CubeState;
 
   /**
    * Checks if the Rubiks Cube is solved, optionally for a specific color.


### PR DESCRIPTION
## Summary
- add a private `_state` property to `Cube`
- expose cube state with a getter that returns a cloned snapshot
- update implementation to work with `_state`
- mark `ICube.state` as readonly and document snapshot semantics
- document new snapshot behaviour in USAGE docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ed2ee0650833290ff38d1a714f7b8