### PR TITLE
Add tests for Cube.state deep copy

### DIFF
--- a/src/cube/tests/stateGetter.test.ts
+++ b/src/cube/tests/stateGetter.test.ts
@@ -1,0 +1,21 @@
+import { Cube } from '../..';
+import { newCubeState } from '../../lib/factory';
+
+describe('Cube state getter', () => {
+  it('should return a deep copy of the cube state', () => {
+    const cube = new Cube(newCubeState());
+    const first = cube.state;
+    const second = cube.state;
+
+    expect(first).not.toBe(second);
+    expect(first[0]).not.toBe(second[0]);
+    expect(first[0][0]).not.toBe(second[0][0]);
+  });
+
+  it('modifying the returned state should not mutate the cube', () => {
+    const cube = new Cube(newCubeState());
+    const copy = cube.state;
+    copy[0][0][0] = 99;
+    expect(cube.state[0][0][0]).not.toBe(99);
+  });
+});


### PR DESCRIPTION
## Summary
- add new test verifying that `Cube.state` returns a deep copy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68701941ae6c8332ad871be3099e89b4