### PR TITLE
Fix orientation type and mappings

### DIFF
--- a/src/operator/actions/orientate.ts
+++ b/src/operator/actions/orientate.ts
@@ -3,7 +3,10 @@ import { Orientation } from '../../cube/lib';
 import { LayersVertex } from '../../lib';
 import { Turn, TurnType } from '../types';
 
-const faceMapping: Record<string, any> = {
+type FaceChar = 'u' | 'd' | 'f' | 'b' | 'l' | 'r';
+type OrientationChar = 'U' | 'D' | 'F' | 'B' | 'L' | 'R';
+
+const faceMapping: Record<FaceChar, Orientation> = {
   u: Orientation.TOP,
   d: Orientation.BOTTOM,
   f: Orientation.FRONT,
@@ -12,7 +15,7 @@ const faceMapping: Record<string, any> = {
   r: Orientation.RIGHT,
 };
 
-const orientationMapping: Record<string, any> = {
+const orientationMapping: Record<OrientationChar, Orientation> = {
   U: Orientation.TOP,
   D: Orientation.BOTTOM,
   F: Orientation.FRONT,
@@ -21,10 +24,10 @@ const orientationMapping: Record<string, any> = {
   R: Orientation.RIGHT,
 };
 
-function orientationsForToken(token: string): [Orientation, Orientation] {
+function orientationsForToken(token: string): [Orientation | undefined, Orientation | undefined] {
   if (!token) return [undefined, undefined];
-  const sourceFace = token[0];
-  const targetAxis = token[1];
+  const sourceFace = token[0] as FaceChar;
+  const targetAxis = token[1] as OrientationChar;
 
   return [faceMapping[sourceFace], orientationMapping[targetAxis]];
 }

--- a/src/operator/types.ts
+++ b/src/operator/types.ts
@@ -4,7 +4,7 @@ export enum TurnType {
   OuterLayerRotation = 'OuterLayerRotation',
   InnerLayerRotation = 'InnerLayerRotation',
   CubeRotation = 'CubeRotation',
-  Orientation = 'Orienation',
+  Orientation = 'Orientation',
 }
 
 export type Turn = {


### PR DESCRIPTION
## Summary
- correct the TurnType enum value for `Orientation`
- replace `Record<string, any>` mappings with typed `Record` definitions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870e22f695c8332904890715537f29d